### PR TITLE
Added failing tests where the path contains same name directories

### DIFF
--- a/lib/PathFinder.php
+++ b/lib/PathFinder.php
@@ -10,7 +10,7 @@ class PathFinder
     /**
      * @var string
      */
-    private $projectRoot;
+    private $basePath;
 
     /**
      * @var array<string,Pattern>
@@ -20,19 +20,28 @@ class PathFinder
     /**
      * @param array<string, Pattern> $destinations
      */
-    private function __construct(string $projectRoot, array $destinations)
+    private function __construct(string $basePath, array $destinations)
     {
-        $this->projectRoot = $projectRoot;
+        $this->basePath = $basePath;
         $this->destinations = $destinations;
     }
 
     /**
-     * @param string $projectRoot
      * @param array<string, string> $destinations
      */
-    public static function fromDestinations($projectRoot, array $destinations): PathFinder
+    public static function fromDestinations(array $destinations): PathFinder
     {
-        return new self($projectRoot, array_map(function (string $pattern) {
+        return new self('', array_map(function (string $pattern) {
+            return Pattern::fromPattern($pattern);
+        }, $destinations));
+    }
+
+    /**
+     * @param array<string, string> $destinations
+     */
+    public static function fromAbsoluteDestinations(string $basePath, array $destinations): PathFinder
+    {
+        return new self($basePath, array_map(function (string $pattern) {
             return Pattern::fromPattern($pattern);
         }, $destinations));
     }
@@ -46,7 +55,9 @@ class PathFinder
      */
     public function destinationsFor(string $filePath): array
     {
-        $filePath = Path::makeRelative($filePath, $this->projectRoot);
+        if ($this->basePath !== '') {
+            $filePath = Path::makeRelative($filePath, $this->basePath);
+        }
 
         $destinations = [];
         $sourcePattern = $this->findSourcePattern($filePath);

--- a/lib/PathFinder.php
+++ b/lib/PathFinder.php
@@ -8,24 +8,32 @@ use Webmozart\PathUtil\Path;
 class PathFinder
 {
     /**
+     * @var sring
+     */
+    private $projectRoot;
+
+    /**
      * @var array<string,Pattern>
      */
     private $destinations = [];
 
     /**
+     * @param string $projectRoot
      * @param array<string, Pattern> $destinations
      */
-    private function __construct(array $destinations)
+    private function __construct($projectRoot, array $destinations)
     {
+        $this->projectRoot = $projectRoot;
         $this->destinations = $destinations;
     }
 
     /**
+     * @param string $projectRoot
      * @param array<string, string> $destinations
      */
-    public static function fromDestinations(array $destinations): PathFinder
+    public static function fromDestinations($projectRoot, array $destinations): PathFinder
     {
-        return new self(array_map(function (string $pattern) {
+        return new self($projectRoot, array_map(function (string $pattern) {
             return Pattern::fromPattern($pattern);
         }, $destinations));
     }
@@ -39,6 +47,12 @@ class PathFinder
      */
     public function destinationsFor(string $filePath): array
     {
+        if (strpos($filePath, $this->projectRoot) === 0) {
+            $length = strlen($this->projectRoot);
+            $removeSlash = substr($this->projectRoot, -1) !== '/' ? 1 : 0;
+            $filePath = substr($filePath, $length + $removeSlash); // +1 to avoid leading slash
+        }
+
         $destinations = [];
         $sourcePattern = $this->findSourcePattern($filePath);
 

--- a/lib/PathFinder.php
+++ b/lib/PathFinder.php
@@ -46,11 +46,7 @@ class PathFinder
      */
     public function destinationsFor(string $filePath): array
     {
-        if (strpos($filePath, $this->projectRoot) === 0) {
-            $length = strlen($this->projectRoot);
-            $removeSlash = substr($this->projectRoot, -1) !== '/' ? 1 : 0;
-            $filePath = substr($filePath, $length + $removeSlash); // +1 to avoid leading slash
-        }
+        $filePath = Path::makeRelative($filePath, $this->projectRoot);
 
         $destinations = [];
         $sourcePattern = $this->findSourcePattern($filePath);

--- a/lib/PathFinder.php
+++ b/lib/PathFinder.php
@@ -8,7 +8,7 @@ use Webmozart\PathUtil\Path;
 class PathFinder
 {
     /**
-     * @var sring
+     * @var string
      */
     private $projectRoot;
 

--- a/lib/PathFinder.php
+++ b/lib/PathFinder.php
@@ -18,10 +18,9 @@ class PathFinder
     private $destinations = [];
 
     /**
-     * @param string $projectRoot
      * @param array<string, Pattern> $destinations
      */
-    private function __construct($projectRoot, array $destinations)
+    private function __construct(string $projectRoot, array $destinations)
     {
         $this->projectRoot = $projectRoot;
         $this->destinations = $destinations;

--- a/lib/Pattern.php
+++ b/lib/Pattern.php
@@ -44,7 +44,7 @@ class Pattern
         $regex = $pattern;
         foreach (array_values($matches[0]) as $index => $token) {
             $greedy = $index + 1 !== count($tokenNames);
-            $regex = '.*' . strtr($regex, [$token => sprintf('(?%s%s+)', $token, $greedy ? '[^/]' : '.')]);
+            $regex = strtr($regex, [$token => sprintf('(?%s%s+)', $token, $greedy ? '[^/]' : '.')]);
         }
 
         if (empty($tokenNames)) {

--- a/lib/Pattern.php
+++ b/lib/Pattern.php
@@ -44,7 +44,7 @@ class Pattern
         $regex = $pattern;
         foreach (array_values($matches[0]) as $index => $token) {
             $greedy = $index + 1 !== count($tokenNames);
-            $regex = strtr($regex, [$token => sprintf('(?%s%s+)', $token, $greedy ? '[^/]' : '.')]);
+            $regex = '.*' . strtr($regex, [$token => sprintf('(?%s%s+)', $token, $greedy ? '[^/]' : '.')]);
         }
 
         if (empty($tokenNames)) {

--- a/tests/Unit/PathFinderTest.php
+++ b/tests/Unit/PathFinderTest.php
@@ -164,6 +164,17 @@ class PathFinderTest extends TestCase
                 'target2' => 'tests/Unit/Test.php',
             ],
         ];
+
+        yield 'one available target with directories with identical name' => [
+            [
+                'target1' => 'src/<kernel>.php',
+                'target2' => 'tests/<kernel>Test.php',
+            ],
+            '/home/user/src/github.com/organisation/project/src/MyFile.php',
+            [
+                'target2' => 'tests/MyFileTest.php',
+            ],
+        ];
     }
 
     public function testNoMatchingTarget(): void

--- a/tests/Unit/PathFinderTest.php
+++ b/tests/Unit/PathFinderTest.php
@@ -9,12 +9,14 @@ use Phpactor\ClassFileConverter\Exception\NoMatchingSourceException;
 
 class PathFinderTest extends TestCase
 {
+    const PROJECT_ROOT = '/home/user/src/github.com/organisation/project';
+
     /**
      * @dataProvider provideTeleport
      */
     public function testTeleport(array $targets, $path, array $expectedTargets): void
     {
-        $teleport = PathFinder::fromDestinations($targets);
+        $teleport = PathFinder::fromDestinations(self::PROJECT_ROOT, $targets);
         $targets = $teleport->destinationsFor($path);
 
         $this->assertEquals($expectedTargets, $targets);
@@ -170,7 +172,7 @@ class PathFinderTest extends TestCase
                 'target1' => 'src/<kernel>.php',
                 'target2' => 'tests/<kernel>Test.php',
             ],
-            '/home/user/src/github.com/organisation/project/src/MyFile.php',
+            self::PROJECT_ROOT . '/src/MyFile.php',
             [
                 'target2' => 'tests/MyFileTest.php',
             ],
@@ -181,7 +183,7 @@ class PathFinderTest extends TestCase
                 'target1' => 'src/<kernel>.php',
                 'target2' => 'tests/<kernel>Test.php',
             ],
-            '/home/user/src/github.com/organisation/project/tests/MyFileTest.php',
+            self::PROJECT_ROOT . '/tests/MyFileTest.php',
             [
                 'target1' => 'src/MyFile.php',
             ],
@@ -191,9 +193,9 @@ class PathFinderTest extends TestCase
     public function testNoMatchingTarget(): void
     {
         $this->expectException(NoMatchingSourceException::class);
-        $this->expectExceptionMessage('Could not find matching source pattern for "/lib/Foo.php", known patterns: "/soos/<kernel>/boos.php"');
+        $this->expectExceptionMessage('Could not find matching source pattern for "lib/Foo.php", known patterns: "/soos/<kernel>/boos.php"');
 
-        $teleport = PathFinder::fromDestinations([
+        $teleport = PathFinder::fromDestinations('/', [
             'soos' => '/soos/<kernel>/boos.php',
         ]);
 
@@ -205,7 +207,7 @@ class PathFinderTest extends TestCase
         $this->expectException(NoPlaceHoldersException::class);
         $this->expectExceptionMessage('File pattern "/soos/boos.php" does not contain any <placeholders>');
 
-        $teleport = PathFinder::fromDestinations([
+        $teleport = PathFinder::fromDestinations('/', [
             'soos' => '/soos/boos.php',
         ]);
 

--- a/tests/Unit/PathFinderTest.php
+++ b/tests/Unit/PathFinderTest.php
@@ -175,6 +175,17 @@ class PathFinderTest extends TestCase
                 'target2' => 'tests/MyFileTest.php',
             ],
         ];
+
+        yield 'jump back to one available target with directories with identical name' => [
+            [
+                'target1' => 'src/<kernel>.php',
+                'target2' => 'tests/<kernel>Test.php',
+            ],
+            '/home/user/src/github.com/organisation/project/tests/MyFileTest.php',
+            [
+                'target1' => 'src/MyFile.php',
+            ],
+        ];
     }
 
     public function testNoMatchingTarget(): void

--- a/tests/Unit/PathFinderTest.php
+++ b/tests/Unit/PathFinderTest.php
@@ -16,7 +16,7 @@ class PathFinderTest extends TestCase
      */
     public function testTeleport(array $targets, $path, array $expectedTargets): void
     {
-        $teleport = PathFinder::fromDestinations(self::PROJECT_ROOT, $targets);
+        $teleport = PathFinder::fromAbsoluteDestinations(self::PROJECT_ROOT, $targets);
         $targets = $teleport->destinationsFor($path);
 
         $this->assertEquals($expectedTargets, $targets);
@@ -193,9 +193,9 @@ class PathFinderTest extends TestCase
     public function testNoMatchingTarget(): void
     {
         $this->expectException(NoMatchingSourceException::class);
-        $this->expectExceptionMessage('Could not find matching source pattern for "lib/Foo.php", known patterns: "/soos/<kernel>/boos.php"');
+        $this->expectExceptionMessage('Could not find matching source pattern for "/lib/Foo.php", known patterns: "/soos/<kernel>/boos.php"');
 
-        $teleport = PathFinder::fromDestinations('/', [
+        $teleport = PathFinder::fromDestinations([
             'soos' => '/soos/<kernel>/boos.php',
         ]);
 
@@ -207,7 +207,7 @@ class PathFinderTest extends TestCase
         $this->expectException(NoPlaceHoldersException::class);
         $this->expectExceptionMessage('File pattern "/soos/boos.php" does not contain any <placeholders>');
 
-        $teleport = PathFinder::fromDestinations('/', [
+        $teleport = PathFinder::fromDestinations([
             'soos' => '/soos/boos.php',
         ]);
 


### PR DESCRIPTION
I ran into this issue where it would try to create a unit test in a wrong location:

Example of how I usually structure my projects. With absolute URLs to indicate how/where it went wrong:
```
Source:   /home/user/src/github.com/organisation/project/src/Domain/Source.php
UnitTest: /home/user/src/github.com/organisation/project/tests/unit/Domain/SourceTest.php
```
But the path finder tried to locate the unit test here:
```
/home/user/src/github.com/organisation/tests/unit/github.com/organisation/project/src/Domain/SourceTest.php
```

So instead of matching on `src/Domain/Source.php` it matched on `src/github.com/organisation/project/src/Domain/Source.php`

(Possible fix incoming, but I want to trigger a build with a failing test first)